### PR TITLE
Synthetic tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,8 +4,8 @@ root = true
 charset = utf-8
 
 [*.py]
-indent_style = tab
-indent_size = 8
+indent_style = space
+indent_size = 4
 
 [.travis.yml]
 indent_style = space

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -1,5 +1,6 @@
 import numpy as np
 
 
-def generate_synthetic_data(shape):
-    return np.zeros(shape)
+def generate_synthetic_data(shape=(1024, 1024), background_level=100, background_sigma=5):
+    background = np.random.normal(background_level, background_sigma, size=shape)
+    return background

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -1,7 +1,17 @@
 import numpy as np
 
+
 def generate_background(shape, background_level, background_sigma):
     return np.random.normal(background_level, background_sigma, size=shape)
+
+
+def generate_signals(shape, positions):
+    out = np.zeros(shape)
+    for position in positions:
+        x, y = position
+        out[y, x] = 1.
+    return out
+
 
 def generate_synthetic_data(shape=(1024, 1024), background_level=100, background_sigma=5):
     return generate_background(

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -37,6 +37,8 @@ def generate_synthetic_data(
         background_level=background_level,
         background_sigma=background_sigma)
     deltas = generate_signals(shape=shape, positions=positions)
+    if np.allclose(deltas, 0.):
+        raise ValueError("No stars found in the synthetic image")
     blurred = gaussian_filter(deltas, sigma=2.35 * psf_pix)
     blurred_max = blurred.max()
     blurred_scaled = blurred * peak_height / blurred_max

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -1,11 +1,18 @@
 import numpy as np
+from scipy.ndimage import gaussian_filter
 
 
 def generate_background(shape, background_level, background_sigma):
+    '''
+    Generates a Gaussian background signal, with the supplied level and sigma
+    '''
     return np.random.normal(background_level, background_sigma, size=shape)
 
 
 def generate_signals(shape, positions):
+    '''
+    Generates delta functions at the specified positions
+    '''
     out = np.zeros(shape)
     for position in positions:
         x, y = position
@@ -14,6 +21,9 @@ def generate_signals(shape, positions):
 
 
 def generate_synthetic_data(shape=(1024, 1024), background_level=100, background_sigma=5):
+    '''
+    Generates synthetic data, consisting of a flat gaussian background, with Gaussians for stars.
+    '''
     return generate_background(
         shape=shape,
         background_level=background_level,

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+
+def generate_synthetic_data(shape):
+    return np.zeros(shape)

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -20,11 +20,23 @@ def generate_signals(shape, positions):
     return out
 
 
-def generate_synthetic_data(shape=(1024, 1024), background_level=100, background_sigma=5):
+def generate_synthetic_data(
+    positions,
+    shape=(1024, 1024),
+    background_level=100,
+    background_sigma=5,
+    peak_height=1000.,
+    psf_pix=1.6,
+):
     '''
     Generates synthetic data, consisting of a flat gaussian background, with Gaussians for stars.
     '''
-    return generate_background(
+    background = generate_background(
         shape=shape,
         background_level=background_level,
         background_sigma=background_sigma)
+    deltas = generate_signals(shape=shape, positions=positions)
+    blurred = gaussian_filter(deltas, sigma=2.35 * psf_pix)
+    blurred_max = blurred.max()
+    blurred_scaled = blurred * peak_height / blurred_max
+    return background + blurred_scaled

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -1,4 +1,5 @@
 import numpy as np
+from astropy.io import fits
 from scipy.ndimage import gaussian_filter
 
 
@@ -40,3 +41,9 @@ def generate_synthetic_data(
     blurred_max = blurred.max()
     blurred_scaled = blurred * peak_height / blurred_max
     return background + blurred_scaled
+
+
+def save_synthetic_data(filename, *args, **kwargs):
+    data = generate_synthetic_data(*args, **kwargs)
+    phdu = fits.PrimaryHDU(data)
+    phdu.writeto(filename, clobber=True)

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -17,7 +17,10 @@ def generate_signals(shape, positions):
     out = np.zeros(shape)
     for position in positions:
         x, y = position
-        out[y, x] = 1.
+        try:
+            out[y, x] = 1.
+        except IndexError:
+            pass
     return out
 
 

--- a/donuts/tests/synthetic_data.py
+++ b/donuts/tests/synthetic_data.py
@@ -1,6 +1,10 @@
 import numpy as np
 
+def generate_background(shape, background_level, background_sigma):
+    return np.random.normal(background_level, background_sigma, size=shape)
 
 def generate_synthetic_data(shape=(1024, 1024), background_level=100, background_sigma=5):
-    background = np.random.normal(background_level, background_sigma, size=shape)
-    return background
+    return generate_background(
+        shape=shape,
+        background_level=background_level,
+        background_sigma=background_sigma)

--- a/donuts/tests/test_donuts_with_synthetic_data.py
+++ b/donuts/tests/test_donuts_with_synthetic_data.py
@@ -1,0 +1,42 @@
+import numpy as np
+from astropy.io import fits
+from .synthetic_data import (
+    generate_synthetic_data,
+    save_synthetic_data,
+)
+from ..donuts import Donuts
+
+np.random.seed(42)
+
+OVERSCAN_WIDTH = 20
+PRESCAN_WIDTH = 20
+
+
+def write_data(filename, data):
+    full_array = np.zeros((data.shape[0], data.shape[1] + OVERSCAN_WIDTH + PRESCAN_WIDTH))
+    full_array[:, PRESCAN_WIDTH:-OVERSCAN_WIDTH] = data
+
+    phdu = fits.PrimaryHDU(full_array)
+    phdu.header['EXPOSURE'] = 1.
+    phdu.writeto(filename, clobber=True)
+
+
+def test_donuts_with_same_image_gives_0_offsets(tmpdir):
+    refimage = tmpdir.join('refimage.fits')
+    scienceimage = tmpdir.join('scienceimage.fits')
+
+    nstars = 500
+    positions = [row for row in zip(
+        np.random.uniform(0, 1023, nstars),
+        np.random.uniform(0, 1023, nstars))
+    ]
+
+    data = generate_synthetic_data(positions)
+    write_data(str(refimage), data)
+    write_data(str(scienceimage), data)
+
+    d = Donuts(refimage=str(refimage), image_ext=0, exposure='EXPOSURE',
+               normalise=True, subtract_bkg=True, prescan_width=PRESCAN_WIDTH,
+               overscan_width=OVERSCAN_WIDTH, boarder=8, ntiles=16)
+    x, y = d.measure_shift(str(scienceimage))
+    assert np.isclose(x, 0.) and np.isclose(y, 0.)

--- a/donuts/tests/test_integration.py
+++ b/donuts/tests/test_integration.py
@@ -3,16 +3,14 @@ from ..donuts import Donuts
 
 # Test the donuts code using real data
 def test_full_integration():
-	# initialise the class with the settings needed
-	# upon generation of the reference image
-	d = Donuts(refimage = 'IMAGE80520160114005507.fits', image_ext = 0, exposure = 'EXPOSURE', 
-			normalise = True, subtract_bkg = True, prescan_width = 20, overscan_width = 20, boarder = 64, ntiles = 32)
-	# print a summary of the setup
-	d.print_summary()
-	# assumes all the settings from the ref image generation
-	# and calculates the shift between the images
-	imlist=['IMAGE80520160114005520.fits','IMAGE80520160114005533.fits']
-	for image in imlist:
-		x, y = d.measure_shift(checkimage=image)
-
-
+    # initialise the class with the settings needed
+    # upon generation of the reference image
+    d = Donuts(refimage='IMAGE80520160114005507.fits', image_ext=0, exposure='EXPOSURE',
+               normalise=True, subtract_bkg=True, prescan_width=20, overscan_width=20, boarder=64, ntiles=32)
+    # print a summary of the setup
+    d.print_summary()
+    # assumes all the settings from the ref image generation
+    # and calculates the shift between the images
+    imlist = ['IMAGE80520160114005520.fits', 'IMAGE80520160114005533.fits']
+    for image in imlist:
+        x, y = d.measure_shift(checkimage=image)

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -4,3 +4,17 @@ from .synthetic_data import generate_synthetic_data
 def test_generate_shape():
     data = generate_synthetic_data(shape=(10, 10))
     assert data.shape == (10, 10)
+
+
+def test_background_level():
+    background_level = 100
+    background_sigma = 0.01
+    data = generate_synthetic_data(
+        background_level=background_level,
+        background_sigma=background_sigma,
+    )
+
+    expected_min = 95
+    expected_max = 105
+    assert expected_min < data[0][0] < expected_max
+

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -1,4 +1,4 @@
-from .synthetic_data import generate_synthetic_data
+from .synthetic_data import generate_synthetic_data, generate_background
 
 
 def test_generate_shape():
@@ -9,7 +9,8 @@ def test_generate_shape():
 def test_background_level():
     background_level = 100
     background_sigma = 0.01
-    data = generate_synthetic_data(
+    data = generate_background(
+        shape=(10, 10),
         background_level=background_level,
         background_sigma=background_sigma,
     )
@@ -17,4 +18,3 @@ def test_background_level():
     expected_min = 95
     expected_max = 105
     assert expected_min < data[0][0] < expected_max
-

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -29,3 +29,11 @@ def test_generate_deltas():
     assert data[positions[0]] > 0.
     assert data[positions[0][1], positions[0][0] - 1] == 0.
     assert data[0, 0] == 0.
+
+def test_generate_multiple_deltas():
+    positions = [(4, 4), (8, 8), (5, 5)]
+    data = generate_signals(positions=positions, shape=(10, 10))
+    assert data[0, 0] == 0.
+    for position in positions:
+        assert data[position] > 0.
+        assert data[position[1], position[0] - 1] == 0.

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -2,6 +2,7 @@ import numpy as np
 from .synthetic_data import (generate_synthetic_data,
                              generate_background,
                              generate_signals,
+                             save_synthetic_data,
                             )
 
 np.random.seed(42)
@@ -57,3 +58,17 @@ def test_generate_synthetic_data():
         assert np.isclose(data[position], peak_height, rtol=0.8)
 
     assert 20. < data[0, 0] < 150
+
+
+def test_write_file(tmpdir):
+    fname = tmpdir.join('out.fits')
+    positions = [(50, 50)]
+    peak_height = 1000.
+    save_synthetic_data(str(fname),
+        shape=(1024, 1024),
+        background_level=100,
+        background_sigma=10,
+        positions=positions,
+        peak_height=peak_height,
+    )
+    assert fname.isfile()

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -1,11 +1,14 @@
+import numpy as np
 from .synthetic_data import (generate_synthetic_data,
                              generate_background,
                              generate_signals,
                             )
 
+np.random.seed(42)
+
 
 def test_generate_shape():
-    data = generate_synthetic_data(shape=(10, 10))
+    data = generate_synthetic_data(positions=[], shape=(10, 10))
     assert data.shape == (10, 10)
 
 
@@ -30,6 +33,7 @@ def test_generate_deltas():
     assert data[positions[0][1], positions[0][0] - 1] == 0.
     assert data[0, 0] == 0.
 
+
 def test_generate_multiple_deltas():
     positions = [(4, 4), (8, 8), (5, 5)]
     data = generate_signals(positions=positions, shape=(10, 10))
@@ -37,3 +41,19 @@ def test_generate_multiple_deltas():
     for position in positions:
         assert data[position] > 0.
         assert data[position[1], position[0] - 1] == 0.
+
+
+def test_generate_synthetic_data():
+    positions = [(50, 50)]
+    peak_height = 1000.
+    data = generate_synthetic_data(
+        shape=(1024, 1024),
+        background_level=100,
+        background_sigma=10,
+        positions=positions,
+        peak_height=peak_height,
+    )
+    for position in positions:
+        assert np.isclose(data[position], peak_height, rtol=0.8)
+
+    assert 20. < data[0, 0] < 150

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -1,6 +1,7 @@
 from .synthetic_data import (generate_synthetic_data,
                              generate_background,
-                             generate_signals)
+                             generate_signals,
+                            )
 
 
 def test_generate_shape():
@@ -26,4 +27,5 @@ def test_generate_deltas():
     positions = [(4, 4)]
     data = generate_signals(positions=positions, shape=(10, 10))
     assert data[positions[0]] > 0.
+    assert data[positions[0][1], positions[0][0] - 1] == 0.
     assert data[0, 0] == 0.

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -72,3 +72,11 @@ def test_write_file(tmpdir):
         peak_height=peak_height,
     )
     assert fname.isfile()
+
+
+def test_no_stars_raises_error():
+    positions = []
+    with pytest.raises(ValueError) as err:
+        data = generate_synthetic_data(positions)
+
+    assert 'no stars' in str(err).lower()

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -1,0 +1,6 @@
+from .synthetic_data import generate_synthetic_data
+
+
+def test_generate_shape():
+    data = generate_synthetic_data(shape=(10, 10))
+    assert data.shape == (10, 10)

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -1,4 +1,6 @@
-from .synthetic_data import generate_synthetic_data, generate_background
+from .synthetic_data import (generate_synthetic_data,
+                             generate_background,
+                             generate_signals)
 
 
 def test_generate_shape():
@@ -18,3 +20,10 @@ def test_background_level():
     expected_min = 95
     expected_max = 105
     assert expected_min < data[0][0] < expected_max
+
+
+def test_generate_deltas():
+    positions = [(4, 4)]
+    data = generate_signals(positions=positions, shape=(10, 10))
+    assert data[positions[0]] > 0.
+    assert data[0, 0] == 0.

--- a/donuts/tests/test_synthetic_data.py
+++ b/donuts/tests/test_synthetic_data.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 from .synthetic_data import (generate_synthetic_data,
                              generate_background,
@@ -9,7 +10,7 @@ np.random.seed(42)
 
 
 def test_generate_shape():
-    data = generate_synthetic_data(positions=[], shape=(10, 10))
+    data = generate_synthetic_data(positions=[(5, 5)], shape=(10, 10))
     assert data.shape == (10, 10)
 
 
@@ -80,3 +81,9 @@ def test_no_stars_raises_error():
         data = generate_synthetic_data(positions)
 
     assert 'no stars' in str(err).lower()
+
+
+def test_stars_outside_image_are_ignored():
+    positions = [(2048, 2048)]
+    signals = generate_signals((10, 10), positions)
+    assert np.allclose(signals, 0.)


### PR DESCRIPTION
Add some tests on synthetic data.

The code under `donuts/tests/synthetic_data.py` generates multiple gaussians representing stars, and add gaussian noise background to the image. This synthetic image generation is given to donuts for assessing the alignment.

The assessment margins have to be quite close for the testing to match:

```python
assert np.isclose(x, -dx, rtol=0.5, atol=0.1)
assert np.isclose(y, -dy, rtol=0.5, atol=0.1)
```

. I don't know if this is a problem, or how precise the code is expected to be.