### PR TITLE
Update public facing urls to point to rtd.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Donuts
     :target: https://coveralls.io/github/jmccormac01/Donuts?branch=master
     :alt: Test Coverage
 .. image:: https://readthedocs.org/projects/donuts/badge/?version=latest
-    :target: http://donuts.readthedocs.org/en/latest/
+    :target: http://donuts.readthedocs.io/en/latest/
     :alt: Latest Documentation Status
 .. image:: https://badges.gitter.im/jmccormac01/Donuts.svg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
     :target: https://gitter.im/jmccormac01/Donuts
@@ -29,7 +29,7 @@ Donuts
 A science frame autoguiding and image alignment algorithm with sub-pixel
 precision, capable of guiding on defocused stars.
 
-Project documentation: https://donuts.readthedocs.org/en/latest/
+Project documentation: https://donuts.readthedocs.io/en/latest/
 
 Motivation
 ----------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Donuts
     :target: https://coveralls.io/github/jmccormac01/Donuts?branch=master
     :alt: Test Coverage
 .. image:: https://readthedocs.org/projects/donuts/badge/?version=latest
-    :target: http://donuts.readthedocs.org/en/latest/
+    :target: http://donuts.readthedocs.io/en/latest/
     :alt: Latest Documentation Status
 .. image:: https://badges.gitter.im/jmccormac01/Donuts.svg?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
     :target: https://gitter.im/jmccormac01/Donuts


### PR DESCRIPTION
Confusingly the links to the project management and badges must stay the
same.

RTD uses two url endpoints: `.org` for admin/user account pages, and
`.io` for public facing, statically hosted/rendered documentation. Their
email mentions this, and how it will increase XSS and CSRF attacks
through isolation of the two concerns.

#20