### PR TITLE
Extract `Image` class to enable the user to get more information about the shifts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ matrix:
 
         # Do a coverage test in Python 2.
         - python: 2.7
-          env: SETUP_CMD='test --coverage'
+          env: SETUP_CMD='test --coverage' PIP_DEPENDENCIES='mock'
 
         # Python 3.3 doesn't have numpy 1.10 in conda, revoke this commit once
         # it's available in the astropy-ci-extras channel
@@ -73,7 +73,7 @@ matrix:
         - python: 2.6
           env: SETUP_CMD='egg_info'
         - python: 2.6
-          env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.9
+          env: SETUP_CMD='test --remote-data' NUMPY_VERSION=1.9 PIP_DEPENDENCIES='mock'
 
 #         # Check for sphinx doc build warnings - we do this first because it
 #         # may run for a long time
@@ -82,13 +82,14 @@ matrix:
 
         # Try Astropy development version
         - python: 2.7
-          env: SETUP_CMD='test --remote-data' ASTROPY_VERSION=development
+          env: SETUP_CMD='test --remote-data' ASTROPY_VERSION=development PIP_DEPENDENCIES='mock'
+
         - python: 3.5
           env: SETUP_CMD='test --remote-data' ASTROPY_VERSION=development
 
         # Try Astropy lts version
         - python: 2.7
-          env: SETUP_CMD='test --remote-data' ASTROPY_VERSION=lts
+          env: SETUP_CMD='test --remote-data' ASTROPY_VERSION=lts PIP_DEPENDENCIES='mock'
         - python: 3.5
           env: SETUP_CMD='test --remote-data' ASTROPY_VERSION=lts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.10
         - ASTROPY_VERSION=stable
-        - PIP_DEPENDENCIES=''
+        - PIP_DEPENDENCIES='mock'
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
@@ -59,7 +59,7 @@ matrix:
 
         # Do a coverage test in Python 2.
         - python: 2.7
-          env: SETUP_CMD='test --coverage' PIP_DEPENDENCIES='mock'
+          env: SETUP_CMD='test --coverage'
 
         # Python 3.3 doesn't have numpy 1.10 in conda, revoke this commit once
         # it's available in the astropy-ci-extras channel

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ fulltest:
 	python setup.py test -a "--cache-dir=$(FULLTEST_CACHE_DIR)" --remote-data
 
 coverage:
-	python setup.py test -a "--cov donuts --cov-report html --cov-report term"
+	python setup.py test -a "--cov donuts --cov-report html --cov-report term" --remote-data
 
 build-docs:
 	python setup.py build_docs

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ fulltest:
 	python setup.py test -a "--cache-dir=$(FULLTEST_CACHE_DIR)" --remote-data
 
 coverage:
-	python setup.py test -a "--cov donuts --cov-report html --cov-report term" --remote-data
+	python setup.py test -a "--cache-dir=$(FULLTEST_CACHE_DIR) --cov donuts --cov-report html --cov-report term" --remote-data
 
 build-docs:
 	python setup.py build_docs

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ help:
 	@echo "Tasks:"
 	@echo "- test"
 	@echo "- fulltest"
+	@echo "- coverage"
 	@echo "- package"
 	@echo "- build-docs"
 	@echo "- build"
@@ -19,6 +20,9 @@ test:
 fulltest:
 	mkdir -p $(FULLTEST_CACHE_DIR)
 	python setup.py test -a "--cache-dir=$(FULLTEST_CACHE_DIR)" --remote-data
+
+coverage:
+	python setup.py test -a "--cov donuts --cov-report html --cov-report term"
 
 build-docs:
 	python setup.py build_docs

--- a/docs/donuts/advanced.rst
+++ b/docs/donuts/advanced.rst
@@ -1,0 +1,39 @@
+********
+Advanced
+********
+
+For those who want more control over how the data is transformed, we provide a
+number of places to hook into the process.
+
+``Image`` class
+---------------
+
+This class really encapsulates the process of transforming a science image, and
+computing the separation between processed images. The ``Donuts`` class is merely
+a high level API over the ``Image`` class.
+
+The easiest way to customise the transformation process (trimming, normalisation
+and background subtraction) is to subclass ``Image`` and override the
+``preconstruct_hook`` and ``postconstruct_hook`` methods, for example::
+
+    from donuts.image import Image
+
+    class MyCustomImage(Image):
+        def preconstruct_hook(self):
+            self.med_image = np.median(self.raw_image)
+            self.raw_image -= self.med_image
+
+        def postconstruct_hook(self):
+            self.backsub += self.med_image
+
+Then to "install" this custom class into the process, construct a ``Donuts``
+object using the ``image_class`` parameter of the constructor::
+
+    from donuts import Donuts
+
+    d = Donuts(filename, image_class=MyCustomImage)
+
+
+If further customisation is required, override other methods in the process but
+currently no convenience hooks are present to make the process easier. As always
+feel free to check out the source code to see what's going on.

--- a/docs/donuts/api.rst
+++ b/docs/donuts/api.rst
@@ -4,3 +4,6 @@ API
 
 .. autoclass:: donuts.Donuts
     :members:
+
+.. autoclass:: donuts.image.Image
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,7 @@ A science frame autoguiding and image alignment algorithm with sub-pixel precisi
 
     donuts/install.rst
     donuts/user_guide.rst
+    donuts/advanced.rst
     donuts/api.rst
 
 .. note::

--- a/donuts/donuts.py
+++ b/donuts/donuts.py
@@ -68,6 +68,22 @@ class Donuts(object):
         self.reference_image = self.construct_object(self.refimage_filename)
 
     def construct_object(self, filename):
+        '''Builds an ``image_class`` instance which performs most of the work.
+        See the ``Image`` class for more information.
+
+        Parameters
+        ----------
+        filename : str
+            FITS file to open and build an ``image_class`` instance from.
+
+        Returns
+        -------
+        ``image_class`` instance
+
+        Raises
+        ------
+        None
+        '''
         with fits.open(filename) as hdulist:
             hdu = hdulist[self.image_ext]
             image = hdu.data
@@ -130,10 +146,10 @@ class Donuts(object):
 
         Returns
         -------
-        solution_x : float (units pixel)
-            The shift required, in X, to recentre the checkimage into the reference frame
-        solution_y : float (units pixel)
-            The shift required, in Y, to recentre the checkimage into the reference frame
+        image: ``Image``
+            Instance of an ``Image`` object, which has the ``x`` and ``y``
+            atributes storing the value of the shift between the chosen image
+            and reference image (passed to the ``Donuts`` constructor)
 
         Raises
         ------

--- a/donuts/donuts.py
+++ b/donuts/donuts.py
@@ -17,7 +17,7 @@ class Donuts(object):
     None
     '''
 
-    def __init__(self, refimage_filename, image_ext=0, exposure_keyname='EXPTIME',
+    def __init__(self, refimage, image_ext=0, exposure='EXPTIME',
                  normalise=True, subtract_bkg=True, prescan_width=0,
                  overscan_width=0, border=64, ntiles=32, image_class=Image):
         '''Initialise and generate a reference image.
@@ -25,11 +25,11 @@ class Donuts(object):
 
         Parameters
         ----------
-        refimage_filename : str
+        refimage : str
             The image representing the reference frame.
         image_ext: int, optional
             The fits image extension to extract. The default is 0.
-        exposure_keyname : str, optional
+        exposure : str, optional
             Fits header keyword for exposure time. The default is `EXPTIME`.
         normalise : bool, optional
             Convert image counts to counts/s. The default is True.
@@ -57,13 +57,13 @@ class Donuts(object):
         self.image_class = image_class
         self.image_ext = image_ext
         self.ntiles = ntiles
-        self.exposure_keyname = exposure_keyname
+        self.exposure_keyname = exposure
         self.normalise = normalise
         self.subtract_bkg = subtract_bkg
         self.prescan_width = prescan_width
         self.overscan_width = overscan_width
         self.border = border
-        self.refimage_filename = refimage_filename
+        self.refimage_filename = refimage
 
         self.reference_image = self.construct_object(self.refimage_filename)
 

--- a/donuts/donuts.py
+++ b/donuts/donuts.py
@@ -74,6 +74,7 @@ class Donuts(object):
             header = hdu.header
 
         image = self.image_class(image, header)
+        image.preconstruct_hook()
         image.trim(
             prescan_width=self.prescan_width,
             overscan_width=self.overscan_width,
@@ -90,6 +91,7 @@ class Donuts(object):
                 ntiles=self.ntiles
             )
 
+        image.postconstruct_hook()
         image.compute_projections()
 
         return image

--- a/donuts/donuts.py
+++ b/donuts/donuts.py
@@ -108,15 +108,13 @@ class Donuts(object):
         ------
         None
         '''
+        # TODO: print more useful things!
         print('Data Summary:')
-        print('\tIlluminated array size: {0:d} x {1:d} pixels'.format(self.dx, self.dy))
         print('\tExcluding a border of {0:d} pixels'.format(self.border))
-        print('\tMeasuring shifts from central {0:d} x {1:d} pixels'.format(self.w_dimx,
-                                                                            self.w_dimy))
+
         if self.subtract_bkg:
             print('Background Subtraction Summary:')
             print('\tUsing {0:d} x {1:d} grid of tiles'.format(self.ntiles, self.ntiles))
-            print('\tEach {0:d} x {1:d} pixels'.format(self.tilesizex, self.tilesizey))
 
     def measure_shift(self, checkimage_filename):
         '''Generate a check image and measure its offset from the reference

--- a/donuts/donuts.py
+++ b/donuts/donuts.py
@@ -19,7 +19,7 @@ class Donuts(object):
 
     def __init__(self, refimage_filename, image_ext=0, exposure_keyname='EXPTIME',
                  normalise=True, subtract_bkg=True, prescan_width=0,
-                 overscan_width=0, border=64, ntiles=32):
+                 overscan_width=0, border=64, ntiles=32, image_class=Image):
         '''Initialise and generate a reference image.
         This reference image is used for measuring frame to frame offsets.
 
@@ -54,6 +54,7 @@ class Donuts(object):
         ------
         None
         '''
+        self.image_class = image_class
         self.image_ext = image_ext
         self.ntiles = ntiles
         self.exposure_keyname = exposure_keyname
@@ -72,7 +73,7 @@ class Donuts(object):
             image = hdu.data
             header = hdu.header
 
-        image = Image(image, header)
+        image = self.image_class(image, header)
         image.trim(
             prescan_width=self.prescan_width,
             overscan_width=self.overscan_width,

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -1,5 +1,4 @@
 import numpy as np
-import warnings
 from astropy import log
 from astropy import units as u
 from scipy import (

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -12,6 +12,11 @@ from scipy.fftpack import fft, ifft
 
 class Image(object):
     '''Encapsulate the transformations applied to images
+
+    * Normalise
+    * Trim
+    * Remove sky background
+    * Compute projections
     '''
 
     def __init__(self, data, header=None):

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -1,6 +1,48 @@
+import numpy as np
+
+
 class Image(object):
     '''Encapsulate the transformations applied to images
     '''
+
     def __init__(self, data, header):
         self.raw_image = data
+        self.raw_region = None
+        self.sky_background = None
+        self.backsub_region = None
         self.header = header
+        self.proj_x = None
+        self.proj_y = None
+        self.x = None
+        self.y = None
+
+    def trim(self, prescan_width=0, overscan_width=0, border=64):
+        if overscan_width > 0 and prescan_width > 0:
+            image_section = self.raw_image[:, prescan_width:-overscan_width]
+        elif overscan_width > 0:
+            image_section = self.raw_image[:, :-overscan_width]
+        elif prescan_width > 0:
+            image_section = self.raw_image[:, prescan_width:]
+        else:
+            image_section = self.raw_image
+
+        dy, dx = image_section.shape  
+
+        # check if the CCD is a funny shape. Normal CCDs should divide by 16
+        # with no remainder. NITES for example does not (1030,1057)
+        # instead of (1024,1024)
+        rx = dx % 16
+        ry = dy % 16
+        base = 512
+
+        if rx > 0 or ry > 0:
+            dimx = int(dx // base) * base
+            dimy = int(dy // base) * base
+        else:
+            dimx = dx
+            dimy = dy
+
+        # get the reference data, with tweaked shape if needed
+        self.raw_region = image_section[
+            border:dimy - border, border:dimx - border
+        ]

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -80,6 +80,19 @@ class Image(object):
         )
         self.backsub_region = self.raw_region - self.sky_background
 
+    def compute_projections(self):
+        if self.backsub_region is None and self.raw_region is None:
+            region = self.raw_image
+        elif self.backsub_region is None:
+            region = self.raw_region
+        else:
+            region = self.backsub_region
+
+        assert len(region.shape) == 2
+
+        self.proj_x = np.sum(region, axis=0)
+        self.proj_y = np.sum(region, axis=1)
+
     def __generate_bkg_map(self, data, tile_num, tilesizex, tilesizey):
         '''Create a background map.
         This map may be subtracted from each image before doing the cross correlation

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -21,6 +21,7 @@ class Image(object):
         self.raw_region = None
         self.sky_background = None
         self.backsub_region = None
+        self.exposure_time_value = None
         self.proj_x = None
         self.proj_y = None
         self.x = None
@@ -28,19 +29,19 @@ class Image(object):
 
     def normalise(self, exposure_keyword='EXPOSURE'):
         try:
-            exposure_time_value = self.header[exposure_keyword]
+            self.exposure_time_value = self.header[exposure_keyword]
         except KeyError:
             log.warning(
                 'Exposure time keyword "{0}" not found, assuming 1.0'.format(
                     exposure_keyword)
             )
-            exposure_time_value = 1.0
+            self.exposure_time_value = 1.0
 
         if self.raw_region is None:
             raise RuntimeError('Image region has not been computed.'
                                'Please ensure the `#trim` method has been called')
 
-        self.raw_region = self.raw_region / exposure_time_value
+        self.raw_region = self.raw_region / self.exposure_time_value
         return self
 
     def trim(self, prescan_width=0, overscan_width=0, border=64):

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -1,0 +1,6 @@
+class Image(object):
+    '''Encapsulate the transformations applied to images
+    '''
+    def __init__(self, data, header):
+        self.raw_image = data
+        self.header = header

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -1,20 +1,38 @@
 import numpy as np
+import warnings
+from astropy import log
 
 
 class Image(object):
     '''Encapsulate the transformations applied to images
     '''
 
-    def __init__(self, data, header):
+    def __init__(self, data, header=None):
         self.raw_image = data
+        self.header = header or {}
+
         self.raw_region = None
         self.sky_background = None
         self.backsub_region = None
-        self.header = header
         self.proj_x = None
         self.proj_y = None
         self.x = None
         self.y = None
+
+    def normalise(self, exposure_keyword='EXPOSURE'):
+        try:
+            exposure_time_value = self.header[exposure_keyword]
+        except KeyError:
+            log.warning(
+                'Exposure time keyword "{0}" not found, assuming 1.0'.format(
+                    exposure_keyword)
+            )
+            exposure_time_value = 1.0
+
+        self.raw_region = self.raw_region / exposure_time_value
+
+        return self
+
 
     def trim(self, prescan_width=0, overscan_width=0, border=64):
         if overscan_width > 0 and prescan_width > 0:
@@ -46,3 +64,42 @@ class Image(object):
         self.raw_region = image_section[
             border:dimy - border, border:dimx - border
         ]
+
+    def remove_background(self, ntiles=32):
+        dim_x, dim_y = self.raw_region.shape
+        tilesize_x, tilesize_y = dim_x // ntiles, dim_y // ntiles
+
+    def __generate_bkg_map(self, data, tile_num, tilesizex, tilesizey):
+        '''Create a background map.
+        This map may be subtracted from each image before doing the cross correlation
+
+        Parameters
+        ----------
+        data : array-like
+            Image array from which to measure sky background
+        tile_num : int
+            Number of tiles along each axis
+        tilesizex : int
+            Size of tiles in X, pixels
+        tilesizey : int
+            Size of tiles in Y, pixels
+
+        Returns
+        -------
+        bkgmap : array-like
+            2D map of sky background. This can then be subtracted
+            from each image to improve the shift measurement
+
+        Raises
+        ------
+        None
+        '''
+        # create coarse map
+        coarse = np.empty((tile_num, tile_num))
+        for i in range(0, tile_num):
+            for j in range(0, tile_num):
+                coarse[i][j] = np.median(data[(i * tilesizey):(i + 1) * tilesizey,
+                                              (j * tilesizex):(j + 1) * tilesizex])
+        # resample it out to data size
+        bkgmap = ndimage.zoom(coarse, (tilesizey, tilesizex), order=2)
+        return bkgmap

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -119,6 +119,14 @@ class Image(object):
 
         return self
 
+    def preconstruct_hook(self):
+        '''Hook to modify the class before any standard processing'''
+        pass
+
+    def postconstruct_hook(self):
+        '''Hook to modify the class after any standard processing'''
+        pass
+
     def _assert_projections(self):
         '''Make sure the projections have been computed
         '''

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -1,7 +1,13 @@
 import numpy as np
 import warnings
 from astropy import log
-from scipy import ndimage
+from astropy import units as u
+from scipy import (
+    ndimage,
+    conjugate,
+    polyfit,
+)
+from scipy.fftpack import fft, ifft
 
 
 class Image(object):
@@ -79,6 +85,7 @@ class Image(object):
             tilesizey=tilesize_y
         )
         self.backsub_region = self.raw_region - self.sky_background
+        return self
 
     def compute_projections(self):
         if self.backsub_region is None and self.raw_region is None:
@@ -92,6 +99,101 @@ class Image(object):
 
         self.proj_x = self._projection_from_image(region, axis=0)
         self.proj_y = self._projection_from_image(region, axis=1)
+        return self
+
+    def compute_offset(self, reference_image):
+        reference_image._assert_projections()
+        self._assert_projections()
+
+        results = self._cross_correlate(reference_image)
+        z_pos_x, z_pos_y, phi_ref_check_m_x, phi_ref_check_m_y = results
+
+        self.x = self._find_solution(z_pos_x, phi_ref_check_m_x)
+        self.y = self._find_solution(z_pos_y, phi_ref_check_m_y)
+
+        return self
+
+    def _assert_projections(self):
+        '''Make sure the projections have been computed
+        '''
+        if self.proj_x is None or self.proj_y is None:
+            raise ValueError(
+                'Projections for %s have not been computed. '
+                'Please call the #compute_projections method' % self
+            )
+
+    def _find_solution(self, z_pos, phi_ref_check_m):
+        '''Covert the CCF into a shift solution for individual axes
+        The location of the peak in the CCF is converted to a shift
+        in pixels here. Sub pixel resolution is achieved by solving a
+        quadratic for the minimum, using the three pixels around the peak.
+
+        Parameters
+        ----------
+        z_pos : int
+            The location of the peak in the CCF
+        phi_ref_check_m: array-like
+            The CCF array from which to extract a correction
+
+        Returns
+        -------
+        solution : float
+            The shift in pixels between two images along the 
+            given axis
+
+        Raises
+        ------
+        None
+        '''
+        tst = np.empty(3)
+        if z_pos[0][0] <= len(phi_ref_check_m) / 2 and z_pos[0][0] != 0:
+            lra = [z_pos[0][0] - 1, z_pos[0][0], z_pos[0][0] + 1]
+            tst[0] = phi_ref_check_m[lra[0]].real
+            tst[1] = phi_ref_check_m[lra[1]].real
+            tst[2] = phi_ref_check_m[lra[2]].real
+            coeffs = polyfit(lra, tst, 2)
+            solution = -(-coeffs[1] / (2 * coeffs[0]))
+        elif z_pos[0][0] > len(phi_ref_check_m) / 2 and z_pos[0][0] != len(phi_ref_check_m) - 1:
+            lra = [z_pos[0][0] - 1, z_pos[0][0], z_pos[0][0] + 1]
+            tst[0] = phi_ref_check_m[lra[0]].real
+            tst[1] = phi_ref_check_m[lra[1]].real
+            tst[2] = phi_ref_check_m[lra[2]].real
+            coeffs = polyfit(lra, tst, 2)
+            solution = len(phi_ref_check_m) + (coeffs[1] / (2 * coeffs[0]))
+        elif z_pos[0][0] == len(phi_ref_check_m) - 1:
+            lra = [-1, 0, 1]
+            tst[0] = phi_ref_check_m[-2].real
+            tst[1] = phi_ref_check_m[-1].real
+            tst[2] = phi_ref_check_m[0].real
+            coeffs = polyfit(lra, tst, 2)
+            solution = 1 + (coeffs[1] / (2 * coeffs[0]))
+        else:  # if z_pos[0][0] == 0:
+            lra = [1, 0, -1]
+            tst[0] = phi_ref_check_m[-1].real
+            tst[1] = phi_ref_check_m[0].real
+            tst[2] = phi_ref_check_m[1].real
+            coeffs = polyfit(lra, tst, 2)
+            solution = -coeffs[1] / (2 * coeffs[0])
+        return solution * u.pixel
+
+    def _cross_correlate(self, reference_image):
+        # FFT of the projection spectra
+        f_ref_xproj = fft(reference_image.proj_x)
+        f_ref_yproj = fft(reference_image.proj_y)
+        f_check_xproj = fft(self.proj_x)
+        f_check_yproj = fft(self.proj_y)
+        # cross correlate in and look for the maximium correlation
+        f_ref_xproj_conj = conjugate(f_ref_xproj)
+        f_ref_yproj_conj = conjugate(f_ref_yproj)
+        complex_sum_x = f_ref_xproj_conj * f_check_xproj
+        complex_sum_y = f_ref_yproj_conj * f_check_yproj
+        phi_ref_check_m_x = ifft(complex_sum_x)
+        phi_ref_check_m_y = ifft(complex_sum_y)
+        z_x = max(phi_ref_check_m_x)
+        z_pos_x = np.where(phi_ref_check_m_x == z_x)
+        z_y = max(phi_ref_check_m_y)
+        z_pos_y = np.where(phi_ref_check_m_y == z_y)
+        return z_pos_x, z_pos_y, phi_ref_check_m_x, phi_ref_check_m_y
 
     def _projection_from_image(self, data, axis):
         '''Function to define the actual process used to compute the

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -72,7 +72,7 @@ class Image(object):
     def remove_background(self, ntiles=32):
         dim_x, dim_y = self.raw_region.shape
         tilesize_x, tilesize_y = dim_x // ntiles, dim_y // ntiles
-        self.sky_background = self.__generate_bkg_map(
+        self.sky_background = self._generate_bkg_map(
             data=self.raw_region,
             tile_num=ntiles,
             tilesizex=tilesize_x,
@@ -90,10 +90,18 @@ class Image(object):
 
         assert len(region.shape) == 2
 
-        self.proj_x = np.sum(region, axis=0)
-        self.proj_y = np.sum(region, axis=1)
+        self.proj_x = self._projection_from_image(region, axis=0)
+        self.proj_y = self._projection_from_image(region, axis=1)
 
-    def __generate_bkg_map(self, data, tile_num, tilesizex, tilesizey):
+    def _projection_from_image(self, data, axis):
+        '''Function to define the actual process used to compute the
+        projections.  Partially as a point to stub, perhaps as a point to
+        override in a subclass, but also it is easier to understand as it's a
+        pure function
+        '''
+        return np.sum(data, axis=axis)
+
+    def _generate_bkg_map(self, data, tile_num, tilesizex, tilesizey):
         '''Create a background map.
         This map may be subtracted from each image before doing the cross correlation
 

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -78,6 +78,7 @@ class Image(object):
             tilesizex=tilesize_x,
             tilesizey=tilesize_y
         )
+        self.backsub_region = self.raw_region - self.sky_background
 
     def __generate_bkg_map(self, data, tile_num, tilesizex, tilesizey):
         '''Create a background map.

--- a/donuts/tests/test_choosing_image_class.py
+++ b/donuts/tests/test_choosing_image_class.py
@@ -1,0 +1,22 @@
+import pytest
+HAS_MOCK = True
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        HAS_MOCK = False
+
+from .helpers import get_test_filename
+from ..donuts import Donuts
+
+@pytest.mark.skipif(not HAS_MOCK, reason="Cannot import the `mock` library "
+                    "from either the standard library, or as a package")
+def test_custom_image_class():
+    filename = get_test_filename('IMAGE80520160114005507.fits')
+    custom_image_class = mock.MagicMock()
+    d = Donuts(filename, image_class=custom_image_class)
+    assert d.image_class == custom_image_class
+
+    assert len(custom_image_class.mock_calls) > 0

--- a/donuts/tests/test_choosing_image_class.py
+++ b/donuts/tests/test_choosing_image_class.py
@@ -4,9 +4,12 @@ try:
 except ImportError:
     import mock
 
+from astropy.tests.helper import remote_data
+
 from .helpers import get_test_filename
 from ..donuts import Donuts
 
+@remote_data
 def test_custom_image_class():
     filename = get_test_filename('IMAGE80520160114005507.fits')
     custom_image_class = mock.MagicMock()

--- a/donuts/tests/test_choosing_image_class.py
+++ b/donuts/tests/test_choosing_image_class.py
@@ -1,18 +1,12 @@
 import pytest
-HAS_MOCK = True
 try:
     from unittest import mock
 except ImportError:
-    try:
-        import mock
-    except ImportError:
-        HAS_MOCK = False
+    import mock
 
 from .helpers import get_test_filename
 from ..donuts import Donuts
 
-@pytest.mark.skipif(not HAS_MOCK, reason="Cannot import the `mock` library "
-                    "from either the standard library, or as a package")
 def test_custom_image_class():
     filename = get_test_filename('IMAGE80520160114005507.fits')
     custom_image_class = mock.MagicMock()

--- a/donuts/tests/test_donuts_with_synthetic_data.py
+++ b/donuts/tests/test_donuts_with_synthetic_data.py
@@ -95,7 +95,7 @@ def test_same_image_gives_0_offsets(tmpdir):
     write_data(str(refimage), data)
     write_data(str(scienceimage), data)
 
-    d = Donuts(refimage_filename=str(refimage), image_ext=0, exposure_keyname='EXPOSURE',
+    d = Donuts(refimage=str(refimage), image_ext=0, exposure='EXPOSURE',
                normalise=True, subtract_bkg=True, prescan_width=PRESCAN_WIDTH,
                overscan_width=OVERSCAN_WIDTH, border=8, ntiles=16)
     result = d.measure_shift(str(scienceimage))
@@ -136,7 +136,7 @@ def test_known_offset(dx, dy, tmpdir):
     write_data(str(refimage), refimage_data)
     write_data(str(scienceimage), scienceimage_data)
 
-    d = Donuts(refimage_filename=str(refimage), image_ext=0, exposure_keyname='EXPOSURE',
+    d = Donuts(refimage=str(refimage), image_ext=0, exposure='EXPOSURE',
                normalise=True, subtract_bkg=True, prescan_width=PRESCAN_WIDTH,
                overscan_width=OVERSCAN_WIDTH, border=8, ntiles=16)
     result = d.measure_shift(str(scienceimage))

--- a/donuts/tests/test_donuts_with_synthetic_data.py
+++ b/donuts/tests/test_donuts_with_synthetic_data.py
@@ -95,11 +95,11 @@ def test_same_image_gives_0_offsets(tmpdir):
     write_data(str(refimage), data)
     write_data(str(scienceimage), data)
 
-    d = Donuts(refimage=str(refimage), image_ext=0, exposure='EXPOSURE',
+    d = Donuts(refimage_filename=str(refimage), image_ext=0, exposure_keyname='EXPOSURE',
                normalise=True, subtract_bkg=True, prescan_width=PRESCAN_WIDTH,
                overscan_width=OVERSCAN_WIDTH, border=8, ntiles=16)
-    x, y = d.measure_shift(str(scienceimage))
-    assert np.isclose(x.value, 0.) and np.isclose(y.value, 0.)
+    result = d.measure_shift(str(scienceimage))
+    assert np.isclose(result.x.value, 0.) and np.isclose(result.y.value, 0.)
 
 
 @pytest.mark.parametrize('dx,dy', [
@@ -136,11 +136,11 @@ def test_known_offset(dx, dy, tmpdir):
     write_data(str(refimage), refimage_data)
     write_data(str(scienceimage), scienceimage_data)
 
-    d = Donuts(refimage=str(refimage), image_ext=0, exposure='EXPOSURE',
+    d = Donuts(refimage_filename=str(refimage), image_ext=0, exposure_keyname='EXPOSURE',
                normalise=True, subtract_bkg=True, prescan_width=PRESCAN_WIDTH,
                overscan_width=OVERSCAN_WIDTH, border=8, ntiles=16)
-    x, y = d.measure_shift(str(scienceimage))
+    result = d.measure_shift(str(scienceimage))
 
     # Fairly large margin for the tolerence as the values are relatively uncertain
-    assert np.isclose(x.value, -dx, rtol=0.5, atol=0.1)
-    assert np.isclose(y.value, -dy, rtol=0.5, atol=0.1)
+    assert np.isclose(result.x.value, -dx, rtol=0.5, atol=0.1)
+    assert np.isclose(result.y.value, -dy, rtol=0.5, atol=0.1)

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -134,14 +134,15 @@ class TestBackgroundSubtraction(object):
 
 class TestComputeProjections(object):
 
-    def test_projections_are_computed(self, ngts_data):
-        pytest.skip()
+    def test_projections_are_not_populated_after_init(self, ngts_data):
         image = Image(data=ngts_data, header=None)
         assert image.proj_x is None
         assert image.proj_y is None
 
+    def test_projections_are_computed_from_full_raw_image(self, ngts_data):
+        image = Image(data=ngts_data, header=None)
         image.compute_projections()
 
         expected_proj_x, expected_proj_y = compute_projections(ngts_data)
-        assert np.allclose(image.proj_x, expected_proj_x)
-        assert np.allclose(image.proj_y, expected_proj_y)
+        assert image.proj_x.shape == (2048, )
+        assert image.proj_y.shape == (2048, )

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -298,3 +298,12 @@ class TestComputeOffset(object):
 
         testvalue = image2.compute_offset(image)
         assert testvalue is image2
+
+def test_no_exposure_time_keyword_uses_1():
+    data = np.random.uniform(100, 1000, (1024, 1024))
+
+    image = Image(data)
+    image.trim()
+    image.normalise()
+
+    assert np.isclose(image.exposure_time_value, 1.0)

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -95,11 +95,17 @@ class TestImageNormalisation(object):
         image.normalise(exposure_keyword='EXPOSURE')
         assert np.allclose(image.raw_region, original_data)
 
+    def test_no_image_region(self):
+        image = Image(generate_image(2048, 2048))
+
+        with pytest.raises(RuntimeError) as exc_info:
+            image.normalise(exposure_keyword='EXPOSURE')
+
+        assert 'image region' in str(exc_info.value).lower()
 
 class TestBackgroundSubtraction(object):
 
     def test_constant_background(self):
-        pytest.skip()
         image = Image(generate_image(2048, 2048), None)
         image.raw_region = np.ones((2048, 2048))
         image.remove_background()

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -307,3 +307,10 @@ def test_no_exposure_time_keyword_uses_1():
     image.normalise()
 
     assert np.isclose(image.exposure_time_value, 1.0)
+
+def test_image_class_has_pre_setup_hook():
+    image = Image(generate_image(2048, 2048))
+    assert hasattr(image, 'preconstruct_hook')
+
+def test_image_class_has_post_setup_hook():
+    assert hasattr(Image, 'postconstruct_hook')

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -4,14 +4,10 @@ from astropy.io import fits
 import numpy as np
 from .helpers import get_test_filename
 
-HAS_MOCK = True
 try:
     from unittest import mock
 except ImportError:
-    try:
-        import mock
-    except ImportError:
-        HAS_MOCK = False
+    import mock
 
 from ..image import Image
 
@@ -197,8 +193,6 @@ class TestComputeProjections(object):
         assert image.proj_x.shape == (1920, )
         assert image.proj_y.shape == (1920, )
 
-    @pytest.mark.skipif(not HAS_MOCK, reason="Cannot import the `mock` library "
-                        "from either the standard library, or as a package")
     def test_projections_with_backsub_image(self):
         stub_data = np.ones((2048, 2048))
         image = Image(data=stub_data, header=None)
@@ -281,8 +275,6 @@ class TestComputeOffset(object):
         assert self.is_close(test_image.x, expected[0])
         assert self.is_close(test_image.y, expected[1])
 
-    @pytest.mark.skipif(not HAS_MOCK, reason="Cannot import the `mock` library "
-                        "from either the standard library, or as a package")
     # Lots of mocking for functions that will fail without proper setup
     @mock.patch.object(Image, '_assert_projections')
     @mock.patch.object(Image, '_cross_correlate',

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -1,6 +1,7 @@
 import pytest
 from astropy import units as u
 from astropy.io import fits
+from astropy.tests.helper import remote_data
 import numpy as np
 from .helpers import get_test_filename
 
@@ -239,6 +240,7 @@ class TestComputeOffset(object):
 
         return np.isclose(x, y, rtol=0.1, atol=0.1)
 
+    @remote_data
     def test_same_object_gives_same_offset(self, ngts_data):
         i1 = self.build_image(
             get_test_filename('IMAGE80520160114005507.fits')
@@ -260,6 +262,7 @@ class TestComputeOffset(object):
 
         assert 'Please call the #compute_projections method' in str(exc_info.value)
 
+    @remote_data
     def test_known_offsets(self):
         ref_image = self.build_image(
             get_test_filename('IMAGE80520160114005507.fits')

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -1,7 +1,57 @@
+import pytest
+import numpy as np
+
 from donuts.image import Image
+
+
+def generate_image(shape):
+    return np.random.randint(1500, 2**16 - 1, size=shape).astype(
+        np.uint16)
+
+
+@pytest.fixture(scope='module')
+def ngts_data():
+    return generate_image((2048, 2048))
+
+
+def compute_projections(arr):
+    return np.sum(arr, axis=0), np.sum(arr, axis=1)
 
 
 def test_image_stores_parameters():
     image = Image(data='a', header='b')
     assert image.raw_image == 'a'
     assert image.header == 'b'
+
+
+def test_image_has_default_none_for_xy():
+    image = Image(data='a', header='b')
+    assert image.x is None and image.y is None
+
+
+class TestImageShapeReading(object):
+
+    def test_without_border_or_overscans(self):
+        image = Image(generate_image((2048, 2048)), None)
+        image.trim(border=0)
+        assert image.raw_region.shape == (2048, 2048)
+
+    def test_with_border_no_overscan(self):
+        image = Image(generate_image((2048, 2048)), None)
+        image.trim(border=64)
+        assert image.raw_region.shape == (1920, 1920)
+
+    def test_with_border_and_overscans(self):
+        image = Image(generate_image((2048, 2048)), None)
+        image.trim(border=64, overscan_width=20, prescan_width=20)
+        assert image.raw_region.shape == (1920, 1408)
+
+    def test_overscan_only(self):
+        image = Image(generate_image((2048, 2048)), None)
+        image.trim(border=0, overscan_width=20)
+        assert image.raw_region.shape == (2048, 1536)
+
+    def test_prescan_only(self):
+        image = Image(generate_image((2048, 2048)), None)
+        image.trim(border=0, prescan_width=64)
+        assert image.raw_region.shape == (2048, 1984)

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -103,13 +103,33 @@ class TestImageNormalisation(object):
 
         assert 'image region' in str(exc_info.value).lower()
 
+
 class TestBackgroundSubtraction(object):
+
+    def test_background_is_not_populated_after_init(self):
+        image = Image(generate_image(2048, 2048), None)
+        assert image.sky_background is None
+
+    def test_backsub_is_not_populated_after_init(self):
+        image = Image(generate_image(2048, 2048), None)
+        assert image.backsub_region is None
 
     def test_constant_background(self):
         image = Image(generate_image(2048, 2048), None)
         image.raw_region = np.ones((2048, 2048))
         image.remove_background()
         assert np.allclose(image.sky_background, np.ones((2048, 2048)))
+
+    # TODO: add tests for the background subtraction on non-trivial datasets
+
+    def test_backsub_region_is_populated(self):
+        image = Image(generate_image(2048, 2048), None)
+        image.raw_region = np.ones((2048, 2048))
+        image.remove_background()
+
+        assert np.allclose(
+            image.backsub_region,
+            np.zeros((2048, 2048)))
 
 
 class TestComputeProjections(object):

--- a/donuts/tests/test_image.py
+++ b/donuts/tests/test_image.py
@@ -1,0 +1,7 @@
+from donuts.image import Image
+
+
+def test_image_stores_parameters():
+    image = Image(data='a', header='b')
+    assert image.raw_image == 'a'
+    assert image.header == 'b'

--- a/donuts/tests/test_integration.py
+++ b/donuts/tests/test_integration.py
@@ -32,7 +32,7 @@ def test_full_integration():
                normalise=True, subtract_bkg=True, prescan_width=20,
                overscan_width=20, border=64, ntiles=32)
     # print a summary of the setup
-    # d.print_summary()
+    d.print_summary()
     # assumes all the settings from the ref image generation
     # and calculates the shift between the images
     imlist = ['IMAGE80520160114005507.fits',

--- a/donuts/tests/test_integration.py
+++ b/donuts/tests/test_integration.py
@@ -28,11 +28,11 @@ def test_full_integration():
     # upon generation of the reference image
 
     test_ref_image = get_test_filename('IMAGE80520160114005507.fits')
-    d = Donuts(refimage=test_ref_image, image_ext=0, exposure='EXPOSURE',
+    d = Donuts(refimage_filename=test_ref_image, image_ext=0, exposure_keyname='EXPOSURE',
                normalise=True, subtract_bkg=True, prescan_width=20,
                overscan_width=20, border=64, ntiles=32)
     # print a summary of the setup
-    d.print_summary()
+    # d.print_summary()
     # assumes all the settings from the ref image generation
     # and calculates the shift between the images
     imlist = ['IMAGE80520160114005507.fits',
@@ -43,6 +43,6 @@ def test_full_integration():
     for image, x_ex, y_ex in zip(imlist, x_expected, y_expected):
         test_check_image = get_test_filename(image)
 
-        x, y = d.measure_shift(checkimage=test_check_image)
-        assert np.isclose(x.value, x_ex, rtol=0.1, atol=0.1)
-        assert np.isclose(y.value, y_ex, rtol=0.1, atol=0.1)
+        result = d.measure_shift(checkimage_filename=test_check_image)
+        assert np.isclose(result.x.value, x_ex, rtol=0.1, atol=0.1)
+        assert np.isclose(result.y.value, y_ex, rtol=0.1, atol=0.1)

--- a/donuts/tests/test_integration.py
+++ b/donuts/tests/test_integration.py
@@ -50,6 +50,7 @@ def test_full_integration():
         assert np.isclose(result.y.value, y_ex, rtol=0.1, atol=0.1)
 
 
+@remote_data
 def test_custom_preconstruct_code():
     test_ref_image = get_test_filename('IMAGE80520160114005507.fits')
 
@@ -65,6 +66,7 @@ def test_custom_preconstruct_code():
                    border=64, ntiles=32, image_class=CustomImage)
 
 
+@remote_data
 def test_custom_postconstruct_code():
     test_ref_image = get_test_filename('IMAGE80520160114005507.fits')
 

--- a/donuts/tests/test_integration.py
+++ b/donuts/tests/test_integration.py
@@ -1,17 +1,19 @@
 """Real world test of Donuts using real images from NGTS
 """
 import os.path
+import pytest
 import numpy as np
 from astropy.tests.helper import remote_data
 from .helpers import get_test_filename
 from ..donuts import Donuts
+from ..image import Image
 
 
 # Test the donuts code using real data
 @remote_data
 def test_full_integration():
     """Test real world usage of Donuts with real data
-    
+
     Parameters
     ----------
     None
@@ -46,3 +48,33 @@ def test_full_integration():
         result = d.measure_shift(checkimage_filename=test_check_image)
         assert np.isclose(result.x.value, x_ex, rtol=0.1, atol=0.1)
         assert np.isclose(result.y.value, y_ex, rtol=0.1, atol=0.1)
+
+
+def test_custom_preconstruct_code():
+    test_ref_image = get_test_filename('IMAGE80520160114005507.fits')
+
+    class CustomImage(Image):
+
+        def preconstruct_hook(self):
+            raise TypeError('bad')
+
+    with pytest.raises(TypeError):
+        d = Donuts(refimage_filename=test_ref_image, image_ext=0,
+                   exposure_keyname='EXPOSURE', normalise=True,
+                   subtract_bkg=True, prescan_width=20, overscan_width=20,
+                   border=64, ntiles=32, image_class=CustomImage)
+
+
+def test_custom_postconstruct_code():
+    test_ref_image = get_test_filename('IMAGE80520160114005507.fits')
+
+    class CustomImage(Image):
+
+        def postconstruct_hook(self):
+            raise TypeError('bad')
+
+    with pytest.raises(TypeError):
+        d = Donuts(refimage_filename=test_ref_image, image_ext=0,
+                   exposure_keyname='EXPOSURE', normalise=True,
+                   subtract_bkg=True, prescan_width=20, overscan_width=20,
+                   border=64, ntiles=32, image_class=CustomImage)

--- a/donuts/tests/test_integration.py
+++ b/donuts/tests/test_integration.py
@@ -30,7 +30,7 @@ def test_full_integration():
     # upon generation of the reference image
 
     test_ref_image = get_test_filename('IMAGE80520160114005507.fits')
-    d = Donuts(refimage_filename=test_ref_image, image_ext=0, exposure_keyname='EXPOSURE',
+    d = Donuts(refimage=test_ref_image, image_ext=0, exposure='EXPOSURE',
                normalise=True, subtract_bkg=True, prescan_width=20,
                overscan_width=20, border=64, ntiles=32)
     # print a summary of the setup
@@ -59,8 +59,8 @@ def test_custom_preconstruct_code():
             raise TypeError('bad')
 
     with pytest.raises(TypeError):
-        d = Donuts(refimage_filename=test_ref_image, image_ext=0,
-                   exposure_keyname='EXPOSURE', normalise=True,
+        d = Donuts(refimage=test_ref_image, image_ext=0,
+                   exposure='EXPOSURE', normalise=True,
                    subtract_bkg=True, prescan_width=20, overscan_width=20,
                    border=64, ntiles=32, image_class=CustomImage)
 
@@ -74,7 +74,7 @@ def test_custom_postconstruct_code():
             raise TypeError('bad')
 
     with pytest.raises(TypeError):
-        d = Donuts(refimage_filename=test_ref_image, image_ext=0,
-                   exposure_keyname='EXPOSURE', normalise=True,
+        d = Donuts(refimage=test_ref_image, image_ext=0,
+                   exposure='EXPOSURE', normalise=True,
                    subtract_bkg=True, prescan_width=20, overscan_width=20,
                    border=64, ntiles=32, image_class=CustomImage)

--- a/donuts/tests/test_integration2.py
+++ b/donuts/tests/test_integration2.py
@@ -28,6 +28,9 @@ def test_full_integration2():
     d = Donuts(refimage_filename=test_ref_image, image_ext=0, exposure_keyname='EXPTIME',
                normalise=True, subtract_bkg=True, prescan_width=0,
                overscan_width=0, border=64, ntiles=28)
+    
+    # print a summary of the setup
+    d.print_summary()
     # assumes all the settings from the ref image generation
     # and calculates the shift between the images
     imlist = ['J17490840-001.fit',

--- a/donuts/tests/test_integration2.py
+++ b/donuts/tests/test_integration2.py
@@ -25,11 +25,9 @@ def test_full_integration2():
     None
     """
     test_ref_image = get_test_filename('J17490840-001.fit')
-    d = Donuts(refimage=test_ref_image, image_ext=0, exposure='EXPTIME',
+    d = Donuts(refimage_filename=test_ref_image, image_ext=0, exposure_keyname='EXPTIME',
                normalise=True, subtract_bkg=True, prescan_width=0,
                overscan_width=0, border=64, ntiles=28)
-    # print a summary of the setup
-    d.print_summary()
     # assumes all the settings from the ref image generation
     # and calculates the shift between the images
     imlist = ['J17490840-001.fit',
@@ -39,6 +37,6 @@ def test_full_integration2():
     y_expected = [0.00, 2.29, 2.62]
     for image, x_ex, y_ex in zip(imlist, x_expected, y_expected):
         test_check_image = get_test_filename(image)
-        x, y = d.measure_shift(checkimage=test_check_image)
-        assert np.isclose(x.value, x_ex, rtol=0.1, atol=0.1)
-        assert np.isclose(y.value, y_ex, rtol=0.1, atol=0.1)
+        result = d.measure_shift(checkimage_filename=test_check_image)
+        assert np.isclose(result.x.value, x_ex, rtol=0.1, atol=0.1)
+        assert np.isclose(result.y.value, y_ex, rtol=0.1, atol=0.1)

--- a/donuts/tests/test_integration2.py
+++ b/donuts/tests/test_integration2.py
@@ -25,7 +25,7 @@ def test_full_integration2():
     None
     """
     test_ref_image = get_test_filename('J17490840-001.fit')
-    d = Donuts(refimage_filename=test_ref_image, image_ext=0, exposure_keyname='EXPTIME',
+    d = Donuts(refimage=test_ref_image, image_ext=0, exposure='EXPTIME',
                normalise=True, subtract_bkg=True, prescan_width=0,
                overscan_width=0, border=64, ntiles=28)
     

--- a/donuts/tests/test_read_image.py
+++ b/donuts/tests/test_read_image.py
@@ -4,17 +4,6 @@ from astropy.io import fits
 
 from donuts import Donuts
 
-def test_no_exposure_time_keyword_uses_1(tmpdir):
-    fname = tmpdir.join('test.fits')
-    data = np.random.uniform(100, 1000, (1024, 1024))
-
-    phdu = fits.PrimaryHDU(data)
-    # No EXPTIME keyword
-    phdu.writeto(str(fname), clobber=True)
-
-    d = Donuts(str(fname))
-    assert np.isclose(d.texp, 1.0)
-
 
 def test_open_invalid_filename(tmpdir):
     fname = tmpdir.join('test.fits')

--- a/donuts/tests/test_summary.py
+++ b/donuts/tests/test_summary.py
@@ -1,5 +1,6 @@
 import pytest
 from astropy.io import fits
+from astropy.tests.helper import remote_data
 from .helpers import get_test_filename
 from ..donuts import Donuts
 
@@ -17,6 +18,7 @@ def build_object(subtract_background):
     )
 
 
+@remote_data
 @pytest.mark.parametrize('expected', [
     'Data Summary',
     'Excluding a border of 64 pixels',
@@ -29,6 +31,7 @@ def test_printing(expected, capsys):
     assert expected in out
 
 
+@remote_data
 def test_with_background_subtraction(capsys):
     dobj = build_object(subtract_background=True)
     dobj.print_summary()
@@ -36,6 +39,7 @@ def test_with_background_subtraction(capsys):
     assert 'Background Subtraction Summary' in out
 
 
+@remote_data
 def test_without_background_subtraction(capsys):
     dobj = build_object(subtract_background=False)
     dobj.print_summary()

--- a/donuts/tests/test_summary.py
+++ b/donuts/tests/test_summary.py
@@ -1,0 +1,43 @@
+import pytest
+from astropy.io import fits
+from .helpers import get_test_filename
+from ..donuts import Donuts
+
+
+def build_object(subtract_background):
+    filename = get_test_filename('IMAGE80520160114005507.fits')
+    return Donuts(
+        refimage_filename=filename,
+        exposure_keyname='EXPOSURE',
+        prescan_width=20,
+        overscan_width=20,
+        ntiles=32,
+        border=64,
+        subtract_bkg=subtract_background
+    )
+
+
+@pytest.mark.parametrize('expected', [
+    'Data Summary',
+    'Excluding a border of 64 pixels',
+    'Using 32 x 32 grid of tiles',
+])
+def test_printing(expected, capsys):
+    dobj = build_object(subtract_background=True)
+    dobj.print_summary()
+    out, _ = capsys.readouterr()
+    assert expected in out
+
+
+def test_with_background_subtraction(capsys):
+    dobj = build_object(subtract_background=True)
+    dobj.print_summary()
+    out, _ = capsys.readouterr()
+    assert 'Background Subtraction Summary' in out
+
+
+def test_without_background_subtraction(capsys):
+    dobj = build_object(subtract_background=False)
+    dobj.print_summary()
+    out, _ = capsys.readouterr()
+    assert 'Background Subtraction Summary' not in out

--- a/donuts/tests/test_summary.py
+++ b/donuts/tests/test_summary.py
@@ -7,8 +7,8 @@ from ..donuts import Donuts
 def build_object(subtract_background):
     filename = get_test_filename('IMAGE80520160114005507.fits')
     return Donuts(
-        refimage_filename=filename,
-        exposure_keyname='EXPOSURE',
+        refimage=filename,
+        exposure='EXPOSURE',
         prescan_width=20,
         overscan_width=20,
         ntiles=32,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ astropy==1.1.2
 mock==2.0.0
 numpy==1.11.0
 scipy==0.17.0
+pytest-cov==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+astropy==1.1.2
+mock==2.0.0
+numpy==1.11.0
+scipy==0.17.0


### PR DESCRIPTION
See #23 

The design ended up moving *most* of the functionality to the `Image` class, with the `Donuts` class creating an easy to use high level api.

The advantages of this architecture are:

* the user has access to more information about both the reference image and test image, e.g. the projections for each, the sky background subtracted data
* the user can subclass the `Image` object and provide some limited customisability through `Image#preconstruct_hook` and `Image#postconstruct_hook` during the setup phase
* the process applied to both the image and separate sub-images is identical (DRY)
* there is very little state stored on the `Donuts` instance, and no state is changed in the `Donuts#measure_shift` method meaning isolated thread-safe running

There are a few downsides:

* the new `Image` class when populated is quite large, with multiple large numpy arrays. On the other hand they have to exist at some point so general memory usage shouldn't go up and provided there are not too many references to the data they should get garbage collected ok
* (minor) all `Image` setup methods are state changing rather than being pure and functional which annoys me...
* at the moment the setup is complicated and fragile. The setup methods `trim`, `normalise`,  and `subtract_background` _must_ be called in that order and testing this will cause `n**2` tests to check the order for `n` methods added