### PR TITLE
Change resize mode to `edge`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Change log
 
+[Unreleased]
+
+## Changes
+
+- Changed `resize` mode `nearest` to be `edge` as per a deprecation warning
+
 ## v0.1.0 - restarted repo, lost all previous changes - 02/06/2016
+
+[Unreleased]: https://github.com/jmccormac01/Donuts/compare/v0.1.0...devel
 

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -379,6 +379,6 @@ class Image(object):
         bkgmap = resize(
             coarse,
             (tilesizey * tile_num, tilesizex * tile_num),
-            mode='nearest'
+            mode='edge'
         )
         return bkgmap

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -376,9 +376,19 @@ class Image(object):
                 coarse[i][j] = np.median(data[(i * tilesizey):(i + 1) * tilesizey,
                                               (j * tilesizex):(j + 1) * tilesizex])
         # resample it out to data size
-        bkgmap = resize(
-            coarse,
-            (tilesizey * tile_num, tilesizex * tile_num),
-            mode='edge'
-        )
+        try:
+            bkgmap = resize(
+                coarse,
+                (tilesizey * tile_num, tilesizex * tile_num),
+                mode='edge'
+            )
+        except ValueError:
+            # "edge" mode is not supported on the current version of
+            # scikit-image
+            bkgmap = resize(
+                coarse,
+                (tilesizey * tile_num, tilesizex * tile_num),
+                mode='nearest'
+            )
+
         return bkgmap


### PR DESCRIPTION
This should prevent the deprecation warnings as shown in #37 