### PR TITLE
adding support for rotated pre/overscan

### DIFF
--- a/donuts/donuts.py
+++ b/donuts/donuts.py
@@ -19,7 +19,8 @@ class Donuts(object):
 
     def __init__(self, refimage, image_ext=0, exposure='EXPTIME',
                  normalise=True, subtract_bkg=True, prescan_width=0,
-                 overscan_width=0, border=64, ntiles=32, image_class=Image):
+                 overscan_width=0, scan_direction='x', border=64,
+                 ntiles=32, image_class=Image):
         '''Initialise and generate a reference image.
         This reference image is used for measuring frame to frame offsets.
 
@@ -39,6 +40,8 @@ class Donuts(object):
             Width of prescan region (left) in pixels. The default is 0.
         overscan_width : int, optional
             Width of overscan region (right) in pixels. The default is 0.
+        scan_direction : str, optional
+            Direction along which the pre/overscan regions are found ('x' | 'y')
         border : int, optional
             Width of exclusion area to avoid errors from CCD edge effects.
             The default is 64.
@@ -62,6 +65,7 @@ class Donuts(object):
         self.subtract_bkg = subtract_bkg
         self.prescan_width = prescan_width
         self.overscan_width = overscan_width
+        self.scan_direction = scan_direction
         self.border = border
         self.refimage_filename = refimage
 
@@ -94,6 +98,7 @@ class Donuts(object):
         image.trim(
             prescan_width=self.prescan_width,
             overscan_width=self.overscan_width,
+            scan_direction=self.scan_direction,
             border=self.border
         )
 

--- a/donuts/image.py
+++ b/donuts/image.py
@@ -62,7 +62,8 @@ class Image(object):
         self.raw_region = self.raw_region / self.exposure_time_value
         return self
 
-    def trim(self, prescan_width=0, overscan_width=0, border=64):
+    def trim(self, prescan_width=0, overscan_width=0,
+             scan_direction='x', border=64):
         '''Remove the optional prescan and overscan from the image, as well
         as the outer `n` rows/colums of the image. Finally ensure the imaging
         region is the correct dimensions for :py:func:`skimage.transform.resize`
@@ -77,6 +78,10 @@ class Image(object):
         overscan_width : int
             Remove the last ``overscan_width`` columns from the image, assuming
             the are not in the imaging region.
+
+        scan_direction : 'x' | 'y'
+            Direction along which the pre/overscans occur. If along left and right
+            side, select 'x'. If along the top and bottom of the image select 'y'
 
         border : int
             Ignore the first/last ``border`` rows/columns from the image,
@@ -95,11 +100,20 @@ class Image(object):
 
         '''
         if overscan_width > 0 and prescan_width > 0:
-            image_section = self.raw_image[:, prescan_width:-overscan_width]
+            if scan_direction == 'x':
+                image_section = self.raw_image[:, prescan_width:-overscan_width]
+            else:
+                image_section = self.raw_image[prescan_width:-overscan_width, :]
         elif overscan_width > 0:
-            image_section = self.raw_image[:, :-overscan_width]
+            if scan_direction == 'x':
+                image_section = self.raw_image[:, :-overscan_width]
+            else:
+                image_section = self.raw_image[:-overscan_width, :]
         elif prescan_width > 0:
-            image_section = self.raw_image[:, prescan_width:]
+            if scan_direction == 'x':
+                image_section = self.raw_image[:, prescan_width:]
+            else:
+                image_section = self.raw_image[prescan_width:, :]
         else:
             image_section = self.raw_image
 


### PR DESCRIPTION
SPECULOOS images are rotated by 90deg. Assuming pre and overscans occur along the left and right (x) is no longer valid. Adding support to change this. 