### PR TITLE
Remove deprecated versions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include CHANGES.rst
 include ez_setup.py
 include ah_bootstrap.py
 include setup.cfg
+include donuts_version.py
 
 recursive-include *.pyx *.c *.pxd
 recursive-include docs *

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py27, py34, py35, py36
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
The Python foundation no longer support pythons 2.6 or 3.3.

In addition, test on python 3.6 as it's the current latest and greatest.